### PR TITLE
Añadir endpoints y lógica para manejo de tokens de renovación

### DIFF
--- a/Prestamium.Api/Controllers/AuthController.cs
+++ b/Prestamium.Api/Controllers/AuthController.cs
@@ -29,4 +29,18 @@ public class AuthController : ControllerBase
         var response = await _authService.LoginAsync(request);
         return response.Success ? Ok(response) : BadRequest(response);
     }
+
+    [HttpPost("refresh-token")]
+    public async Task<IActionResult> RefreshToken([FromBody] RefreshTokenRequestDto request)
+    {
+        var response = await _authService.RefreshTokenAsync(request.RefreshToken);
+        return response.Success ? Ok(response) : BadRequest(response);
+    }
+
+    [HttpPost("revoke-token")]
+    public async Task<IActionResult> RevokeToken([FromBody] RefreshTokenRequestDto request)
+    {
+        var success = await _authService.RevokeTokenAsync(request.RefreshToken);
+        return success ? Ok() : BadRequest("Invalid token");
+    }
 }

--- a/Prestamium.Api/appsettings.Development.json
+++ b/Prestamium.Api/appsettings.Development.json
@@ -6,7 +6,7 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost\\SQLDEV;Database=Prestamium;User ID=sa;Password=12345678;Encrypt=True;TrustServerCertificate=True"
+    "DefaultConnection": "Server=TBTB-LUISCABAL;Database=Prestamium;User ID=sa;Password=082022;Encrypt=True;TrustServerCertificate=True"
   },
   "JwtSettings": {
     "Key": "VSRSGHVFHED87GF8BGFFDBSXHB8GF6BGBNVFGNFB86GNBVB976B867G8FB5F7B9DD9F9F8BV",

--- a/Prestamium.Dto/Request/RefreshTokenRequestDto.cs
+++ b/Prestamium.Dto/Request/RefreshTokenRequestDto.cs
@@ -1,0 +1,7 @@
+﻿namespace Prestamium.Dto.Request
+{
+    public class RefreshTokenRequestDto
+    {
+        public string RefreshToken { get; set; } = string.Empty;
+    }
+}

--- a/Prestamium.Dto/Response/AuthResponseDto.cs
+++ b/Prestamium.Dto/Response/AuthResponseDto.cs
@@ -3,6 +3,8 @@
     public class AuthResponseDto
     {
         public string Token { get; set; } = default!;
+        public string RefreshToken { get; set; } = default!;
+        public DateTime RefreshTokenExpiration { get; set; }
         public string Email { get; set; } = default!;
         public string UserId { get; set; } = default!;
         public string FirstName { get; set; } = default!;

--- a/Prestamium.Entities/RefreshToken.cs
+++ b/Prestamium.Entities/RefreshToken.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Prestamium.Entities
+{
+    public class RefreshToken
+    {
+        public int Id { get; set; }
+        public string Token { get; set; } = string.Empty;
+        public DateTime ExpiryDate { get; set; }
+        public bool IsRevoked { get; set; }
+        public DateTime CreatedDate { get; set; }
+        public string UserId { get; set; } = string.Empty;
+        public User User { get; set; } = default!;
+    }
+}

--- a/Prestamium.Persistence/ApplicationDbContext.cs
+++ b/Prestamium.Persistence/ApplicationDbContext.cs
@@ -12,6 +12,8 @@ namespace Prestamium.Persistence
 
         }
 
+        public DbSet<RefreshToken> RefreshTokens { get; set; }
+
         //Fluent Api
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/Prestamium.Persistence/Migrations/20241203063238_RefreshToken.Designer.cs
+++ b/Prestamium.Persistence/Migrations/20241203063238_RefreshToken.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Prestamium.Persistence;
 
@@ -11,9 +12,11 @@ using Prestamium.Persistence;
 namespace Prestamium.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241203063238_RefreshToken")]
+    partial class RefreshToken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Prestamium.Persistence/Migrations/20241203063238_RefreshToken.cs
+++ b/Prestamium.Persistence/Migrations/20241203063238_RefreshToken.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Prestamium.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class RefreshToken : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RefreshTokens",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Token = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ExpiryDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRevoked = table.Column<bool>(type: "bit", nullable: false),
+                    CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RefreshTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RefreshTokens_User_UserId",
+                        column: x => x.UserId,
+                        principalTable: "User",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RefreshTokens_UserId",
+                table: "RefreshTokens",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RefreshTokens");
+        }
+    }
+}

--- a/Prestamium.Services/Interfaces/IAuthService.cs
+++ b/Prestamium.Services/Interfaces/IAuthService.cs
@@ -7,5 +7,7 @@ namespace Prestamium.Services.Interfaces
     {
         Task<BaseResponseGeneric<AuthResponseDto>> LoginAsync(LoginRequestDto loginRequestDto);
         Task<BaseResponseGeneric<AuthResponseDto>> RegisterAsync(RegisterRequestDto registerRequestDto);
+        Task<BaseResponseGeneric<AuthResponseDto>> RefreshTokenAsync(string refreshToken);
+        Task<bool> RevokeTokenAsync(string refreshToken);
     }
 }


### PR DESCRIPTION
Se han añadido dos nuevos endpoints en el `AuthController` para manejar la renovación (`refresh-token`) y revocación (`revoke-token`) de tokens de renovación.

Se ha actualizado la cadena de conexión en `appsettings.Development.json` para apuntar a un nuevo servidor de base de datos.

Se han creado las clases `RefreshTokenRequestDto`, `AuthResponseDto` y `RefreshToken` para manejar los tokens de renovación en la base de datos.

Se ha añadido un `DbSet<RefreshToken>` en `ApplicationDbContext.cs` y se ha creado una nueva migración `20241203063238_RefreshToken` para añadir la tabla `RefreshTokens` en la base de datos.

Se han añadido métodos `RefreshTokenAsync` y `RevokeTokenAsync` en la interfaz `IAuthService` y se ha actualizado la implementación de `AuthService` para incluir la lógica de generación, renovación y revocación de tokens de renovación.